### PR TITLE
v3.1.1

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 3.x versions.
 
 
+## v3.1.1
+* Remove use of mixin/message constants for fields and schema refs as it's too noisy and isn't enough of a help to warrant it.
+
+
 ## v3.1.0
 * Add optional context arg to `Pbjx::sendAt` and `Pbjx::cancelJobs` and the `Scheduler` methods to allow for customization and remove final keyword so multi-tenant apps can dynamically change table or state machine.
 * Add `EventDispatcher` requirement to `DynamoDbScheduler` constructor.

--- a/src/Consumer/AbstractConsumer.php
+++ b/src/Consumer/AbstractConsumer.php
@@ -9,9 +9,6 @@ use Gdbots\Pbj\Util\NumberUtil;
 use Gdbots\Pbj\Util\StringUtil;
 use Gdbots\Pbjx\PbjxEvents;
 use Gdbots\Pbjx\ServiceLocator;
-use Gdbots\Schemas\Pbjx\Mixin\Command\CommandV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\Request\RequestV1Mixin;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -151,17 +148,17 @@ abstract class AbstractConsumer
 
     final protected function handleMessage(Message $message): ?Message
     {
-        if ($message::schema()->hasMixin(CommandV1Mixin::SCHEMA_CURIE)) {
+        if ($message::schema()->hasMixin('gdbots:pbjx:mixin:command')) {
             $this->handleCommand($message);
             return null;
         }
 
-        if ($message::schema()->hasMixin(EventV1Mixin::SCHEMA_CURIE)) {
+        if ($message::schema()->hasMixin('gdbots:pbjx:mixin:event')) {
             $this->handleEvent($message);
             return null;
         }
 
-        if ($message::schema()->hasMixin(RequestV1Mixin::SCHEMA_CURIE)) {
+        if ($message::schema()->hasMixin('gdbots:pbjx:mixin:request')) {
             return $this->handleRequest($message);
         }
     }

--- a/src/Event/EnrichContextEvent.php
+++ b/src/Event/EnrichContextEvent.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Gdbots\Pbjx\Event;
 
 use Gdbots\Pbj\Message;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
 
 final class EnrichContextEvent
 {
@@ -21,8 +20,8 @@ final class EnrichContextEvent
         if (isset($context['causator']) && $context['causator'] instanceof Message) {
             $this->causator = $context['causator'];
 
-            if (!isset($context['tenant_id']) && $this->causator->has(EventV1Mixin::CTX_TENANT_ID_FIELD)) {
-                $context['tenant_id'] = $this->causator->get(EventV1Mixin::CTX_TENANT_ID_FIELD);
+            if (!isset($context['tenant_id']) && $this->causator->has('ctx_tenant_id')) {
+                $context['tenant_id'] = $this->causator->get('ctx_tenant_id');
             }
         }
 

--- a/src/Event/GetResponseEvent.php
+++ b/src/Event/GetResponseEvent.php
@@ -5,7 +5,6 @@ namespace Gdbots\Pbjx\Event;
 
 use Gdbots\Pbj\Message;
 use Gdbots\Pbjx\Exception\LogicException;
-use Gdbots\Schemas\Pbjx\Mixin\Response\ResponseV1Mixin;
 use Psr\EventDispatcher\StoppableEventInterface;
 
 class GetResponseEvent extends PbjxEvent implements StoppableEventInterface
@@ -40,30 +39,20 @@ class GetResponseEvent extends PbjxEvent implements StoppableEventInterface
             throw new LogicException('Response can only be set one time.');
         }
 
-        if (!$response->has(ResponseV1Mixin::CTX_REQUEST_FIELD)) {
-            $response->set(ResponseV1Mixin::CTX_REQUEST_FIELD, $this->message);
+        if (!$response->has('ctx_request')) {
+            $response->set('ctx_request', $this->message);
         }
 
-        if (!$response->has(ResponseV1Mixin::CTX_REQUEST_REF_FIELD)) {
-            $response->set(ResponseV1Mixin::CTX_REQUEST_REF_FIELD, $this->message->generateMessageRef());
+        if (!$response->has('ctx_request_ref')) {
+            $response->set('ctx_request_ref', $this->message->generateMessageRef());
         }
 
-        if (!$response->has(ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD)
-            && $this->message->has(ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD)
-        ) {
-            $response->set(
-                ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD,
-                $this->message->get(ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD)
-            );
+        if (!$response->has('ctx_correlator_ref') && $this->message->has('ctx_correlator_ref')) {
+            $response->set('ctx_correlator_ref', $this->message->get('ctx_correlator_ref'));
         }
 
-        if (!$response->has(ResponseV1Mixin::CTX_TENANT_ID_FIELD)
-            && $this->message->has(ResponseV1Mixin::CTX_TENANT_ID_FIELD)
-        ) {
-            $response->set(
-                ResponseV1Mixin::CTX_TENANT_ID_FIELD,
-                $this->message->get(ResponseV1Mixin::CTX_TENANT_ID_FIELD)
-            );
+        if (!$response->has('ctx_tenant_id') && $this->message->has('ctx_tenant_id')) {
+            $response->set('ctx_tenant_id', $this->message->get('ctx_tenant_id'));
         }
 
         $this->response = $response;

--- a/src/EventSearch/Elastica/ElasticaEventSearch.php
+++ b/src/EventSearch/Elastica/ElasticaEventSearch.php
@@ -19,9 +19,6 @@ use Gdbots\Pbjx\Exception\EventSearchOperationFailed;
 use Gdbots\Pbjx\PbjxEvents;
 use Gdbots\QueryParser\ParsedQuery;
 use Gdbots\Schemas\Pbjx\Enum\Code;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\SearchEventsRequest\SearchEventsRequestV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\SearchEventsResponse\SearchEventsResponseV1Mixin;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Rfc4122\UuidV1;
@@ -167,10 +164,10 @@ TEXT;
 
             try {
                 /** @var \DateTimeInterface $occurredAt */
-                $occurredAt = $event->get(EventV1Mixin::OCCURRED_AT_FIELD)->toDateTime();
+                $occurredAt = $event->get('occurred_at')->toDateTime();
                 $indexName = $this->indexManager->getIndexNameForWrite($event);
                 $document = $this->marshaler->marshal($event)
-                    ->setId($event->get(EventV1Mixin::EVENT_ID_FIELD)->toString())
+                    ->setId($event->get('event_id')->toString())
                     ->set(
                         IndexManager::OCCURRED_AT_ISO_FIELD_NAME,
                         $occurredAt->format(DateUtil::ISO8601_ZULU)
@@ -187,7 +184,7 @@ TEXT;
 
                 $this->logger->error($message, [
                     'exception'  => $e,
-                    'event_id'   => $event->get(EventV1Mixin::EVENT_ID_FIELD)->toString(),
+                    'event_id'   => $event->get('event_id')->toString(),
                     'pbj'        => $event->toArray(),
                     'index_name' => $indexName,
                 ]);
@@ -281,8 +278,8 @@ TEXT;
         $search = new Search($this->getClientForRead($context));
         $search->addIndices($this->indexManager->getIndexNamesForSearch($request));
 
-        $page = $request->get(SearchEventsRequestV1Mixin::PAGE_FIELD);
-        $perPage = $request->get(SearchEventsRequestV1Mixin::COUNT_FIELD);
+        $page = $request->get('page');
+        $perPage = $request->get('count');
         $offset = ($page - 1) * $perPage;
         $offset = NumberUtil::bound($offset, 0, 10000);
         $options = [
@@ -303,14 +300,14 @@ TEXT;
                     'exception'  => $e,
                     'pbj_schema' => $request->schema()->getId()->toString(),
                     'pbj'        => $request->toArray(),
-                    'query'      => $request->get(SearchEventsRequestV1Mixin::Q_FIELD),
+                    'query'      => $request->get('q'),
                 ]
             );
 
             throw new EventSearchOperationFailed(
                 sprintf(
                     'ElasticSearch query [%s] failed with message: %s',
-                    $request->get(SearchEventsRequestV1Mixin::Q_FIELD),
+                    $request->get('q'),
                     ClassUtil::getShortName($e) . '::' . $e->getMessage()
                 ),
                 Code::INTERNAL,
@@ -333,11 +330,11 @@ TEXT;
         $this->marshaler->skipValidation(false);
 
         $response
-            ->set(SearchEventsResponseV1Mixin::TOTAL_FIELD, $results->getTotalHits())
-            ->set(SearchEventsResponseV1Mixin::HAS_MORE_FIELD, ($offset + $perPage) < $results->getTotalHits() && $offset < 10000)
-            ->set(SearchEventsResponseV1Mixin::TIME_TAKEN_FIELD, (int)($results->getResponse()->getQueryTime() * 1000))
-            ->set(SearchEventsResponseV1Mixin::MAX_SCORE_FIELD, (float)$results->getMaxScore())
-            ->addToList(SearchEventsResponseV1Mixin::EVENTS_FIELD, $events);
+            ->set('total', $results->getTotalHits())
+            ->set('has_more', ($offset + $perPage) < $results->getTotalHits() && $offset < 10000)
+            ->set('time_taken', (int)($results->getResponse()->getQueryTime() * 1000))
+            ->set('max_score', (float)$results->getMaxScore())
+            ->addToList('events', $events);
     }
 
     /**

--- a/src/EventSearch/Elastica/IndexManager.php
+++ b/src/EventSearch/Elastica/IndexManager.php
@@ -11,8 +11,6 @@ use Gdbots\Pbj\Message;
 use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbjx\Exception\EventSearchOperationFailed;
 use Gdbots\Schemas\Pbjx\Enum\Code;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\Indexed\IndexedV1Mixin;
 use Gdbots\Schemas\Pbjx\Mixin\SearchEventsRequest\SearchEventsRequestV1Mixin;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -95,7 +93,7 @@ class IndexManager
     public function getIndexNameForWrite(Message $event): string
     {
         /** @var \DateTimeInterface $occurredAt */
-        $occurredAt = $event->get(EventV1Mixin::OCCURRED_AT_FIELD)->toDateTime();
+        $occurredAt = $event->get('occurred_at')->toDateTime();
         return $this->indexPrefix . $this->getIndexIntervalSuffix($occurredAt);
     }
 
@@ -111,8 +109,8 @@ class IndexManager
     {
         /** @var \DateTime $after */
         /** @var \DateTime $before */
-        $after = $request->get(SearchEventsRequestV1Mixin::OCCURRED_AFTER_FIELD);
-        $before = $request->get(SearchEventsRequestV1Mixin::OCCURRED_BEFORE_FIELD);
+        $after = $request->get('occurred_after');
+        $before = $request->get('occurred_before');
 
         /*
          * when no lower bound is used, we must assume they meant to search
@@ -372,7 +370,7 @@ class IndexManager
     protected function createMapping(): Mapping
     {
         $builder = $this->getMappingBuilder();
-        foreach (MessageResolver::findAllUsingMixin(IndexedV1Mixin::SCHEMA_CURIE_MAJOR) as $curie) {
+        foreach (MessageResolver::findAllUsingMixin('gdbots:pbjx:mixin:indexed:v1') as $curie) {
             $builder->addSchema(MessageResolver::resolveCurie($curie)::schema());
         }
 

--- a/src/EventSearch/Elastica/MappingBuilder.php
+++ b/src/EventSearch/Elastica/MappingBuilder.php
@@ -6,7 +6,6 @@ namespace Gdbots\Pbjx\EventSearch\Elastica;
 use Gdbots\Pbj\Field;
 use Gdbots\Pbj\Marshaler\Elastica\MappingBuilder as BaseMappingBuilder;
 use Gdbots\Pbj\Schema;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
 
 class MappingBuilder extends BaseMappingBuilder
 {
@@ -14,7 +13,7 @@ class MappingBuilder extends BaseMappingBuilder
 
     protected function filterProperties(Schema $schema, Field $field, string $path, array $properties): array
     {
-        if ($field->getName() === EventV1Mixin::CTX_UA_FIELD) {
+        if ($field->getName() === 'ctx_ua') {
             $properties['index'] = false;
             unset($properties['analyzer']);
             unset($properties['copy_to']);

--- a/src/EventSearch/Elastica/QueryFactory.php
+++ b/src/EventSearch/Elastica/QueryFactory.php
@@ -18,7 +18,6 @@ use Gdbots\QueryParser\Node\Field;
 use Gdbots\QueryParser\Node\Numbr;
 use Gdbots\QueryParser\ParsedQuery;
 use Gdbots\Schemas\Pbjx\Enum\SearchEventsSort;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
 use Gdbots\Schemas\Pbjx\Mixin\SearchEventsRequest\SearchEventsRequestV1Mixin;
 
 class QueryFactory
@@ -50,13 +49,13 @@ class QueryFactory
 
         $dateFilters = [
             [
-                'query'    => SearchEventsRequestV1Mixin::OCCURRED_AFTER_FIELD,
-                'field'    => EventV1Mixin::OCCURRED_AT_FIELD,
+                'query'    => 'occurred_after',
+                'field'    => 'occurred_at',
                 'operator' => ComparisonOperator::GT(),
             ],
             [
-                'query'    => SearchEventsRequestV1Mixin::OCCURRED_BEFORE_FIELD,
-                'field'    => EventV1Mixin::OCCURRED_AT_FIELD,
+                'query'    => 'occurred_before',
+                'field'    => 'occurred_at',
                 'operator' => ComparisonOperator::LT(),
             ],
         ];
@@ -107,21 +106,21 @@ class QueryFactory
      */
     protected function createSortedQuery(AbstractQuery $query, Message $request): Query
     {
-        switch ($request->get(SearchEventsRequestV1Mixin::SORT_FIELD)->getValue()) {
+        switch ($request->get('sort')->getValue()) {
             case SearchEventsSort::DATE_DESC:
                 $query = Query::create($query);
-                $query->setSort([EventV1Mixin::OCCURRED_AT_FIELD => 'desc']);
+                $query->setSort(['occurred_at' => 'desc']);
                 break;
 
             case SearchEventsSort::DATE_ASC:
                 $query = Query::create($query);
-                $query->setSort([EventV1Mixin::OCCURRED_AT_FIELD => 'asc']);
+                $query->setSort(['occurred_at' => 'asc']);
                 break;
 
             default:
                 // recency scores higher
                 // @link https://www.elastic.co/guide/en/elasticsearch/guide/current/decay-functions.html
-                $before = $request->get(SearchEventsRequestV1Mixin::OCCURRED_BEFORE_FIELD) ?: new \DateTime('now', new \DateTimeZone('UTC'));
+                $before = $request->get('occurred_before') ?: new \DateTime('now', new \DateTimeZone('UTC'));
                 $query = (new FunctionScore())
                     ->setQuery($query)
                     ->addFunction(FunctionScore::DECAY_EXPONENTIAL, [

--- a/src/EventSearch/EventIndexer.php
+++ b/src/EventSearch/EventIndexer.php
@@ -6,14 +6,13 @@ namespace Gdbots\Pbjx\EventSearch;
 use Gdbots\Pbj\Message;
 use Gdbots\Pbjx\EventSubscriber;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Pbjx\Mixin\Indexed\IndexedV1Mixin;
 
 final class EventIndexer implements EventSubscriber
 {
     public static function getSubscribedEvents()
     {
         return [
-            IndexedV1Mixin::SCHEMA_CURIE => 'onIndexed',
+            'gdbots:pbjx:mixin:indexed' => 'onIndexed',
         ];
     }
 

--- a/src/EventStore/StreamSlice.php
+++ b/src/EventStore/StreamSlice.php
@@ -5,7 +5,6 @@ namespace Gdbots\Pbjx\EventStore;
 
 use Gdbots\Pbj\Message;
 use Gdbots\Pbj\WellKnown\Microtime;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
 use Gdbots\Schemas\Pbjx\StreamId;
 
 final class StreamSlice implements \JsonSerializable, \IteratorAggregate, \Countable
@@ -106,6 +105,6 @@ final class StreamSlice implements \JsonSerializable, \IteratorAggregate, \Count
         $event = end($this->events);
         reset($this->events);
 
-        return $event instanceof Message ? $event->get(EventV1Mixin::OCCURRED_AT_FIELD) : null;
+        return $event instanceof Message ? $event->get('occurred_at') : null;
     }
 }

--- a/src/Exception/RequestHandlingFailed.php
+++ b/src/Exception/RequestHandlingFailed.php
@@ -5,8 +5,6 @@ namespace Gdbots\Pbjx\Exception;
 
 use Gdbots\Pbj\Message;
 use Gdbots\Schemas\Pbjx\Enum\Code;
-use Gdbots\Schemas\Pbjx\Mixin\Request\RequestV1Mixin;
-use Gdbots\Schemas\Pbjx\Request\RequestFailedResponseV1;
 
 final class RequestHandlingFailed extends \RuntimeException implements GdbotsPbjxException, \JsonSerializable
 {
@@ -15,17 +13,16 @@ final class RequestHandlingFailed extends \RuntimeException implements GdbotsPbj
     public function __construct(Message $response)
     {
         $this->response = $response;
-        $ref = $response->get(RequestFailedResponseV1::CTX_REQUEST_REF_FIELD)
-            ?: $response->get(RequestFailedResponseV1::CTX_REQUEST_FIELD)->get(RequestV1Mixin::REQUEST_ID_FIELD);
+        $ref = $response->get('ctx_request_ref') ?: $response->get('ctx_request')->get('request_id');
         parent::__construct(
             sprintf(
-                'Request [%s] could not be handled.  %s::%s::%s',
+                'Request [%s] could not be handled. %s::%s::%s',
                 $ref,
-                $this->response->get(RequestFailedResponseV1::ERROR_NAME_FIELD),
-                $this->response->get(RequestFailedResponseV1::ERROR_CODE_FIELD),
-                $this->response->get(RequestFailedResponseV1::ERROR_MESSAGE_FIELD)
+                $this->response->get('error_name'),
+                $this->response->get('error_code'),
+                $this->response->get('error_message')
             ),
-            $this->response->get(RequestFailedResponseV1::ERROR_CODE_FIELD, Code::UNKNOWN)
+            $this->response->get('error_code', Code::UNKNOWN)
         );
     }
 
@@ -36,7 +33,7 @@ final class RequestHandlingFailed extends \RuntimeException implements GdbotsPbj
 
     public function getRequest(): ?Message
     {
-        return $this->response->get(RequestFailedResponseV1::CTX_REQUEST_FIELD);
+        return $this->response->get('ctx_request');
     }
 
     public function jsonSerialize()

--- a/src/Scheduler/DynamoDb/DynamoDbScheduler.php
+++ b/src/Scheduler/DynamoDb/DynamoDbScheduler.php
@@ -15,7 +15,6 @@ use Gdbots\Pbjx\Exception\SchedulerOperationFailed;
 use Gdbots\Pbjx\PbjxEvents;
 use Gdbots\Pbjx\Scheduler\Scheduler;
 use Gdbots\Schemas\Pbjx\Enum\Code;
-use Gdbots\Schemas\Pbjx\Mixin\Command\CommandV1Mixin;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -98,16 +97,16 @@ class DynamoDbScheduler implements Scheduler
             // a command will not be sent in the same context as we currently
             // have so unset these fields and let the task handler (a lambda generally)
             // populate these fields right before processing.
-            unset($payload[CommandV1Mixin::COMMAND_ID_FIELD]);
-            unset($payload[CommandV1Mixin::OCCURRED_AT_FIELD]);
-            unset($payload[CommandV1Mixin::EXPECTED_ETAG_FIELD]);
-            // unset($payload[CommandV1Mixin::CTX_RETRIES_FIELD]);
-            unset($payload[CommandV1Mixin::CTX_CORRELATOR_REF_FIELD]);
-            unset($payload[CommandV1Mixin::CTX_APP_FIELD]);
-            unset($payload[CommandV1Mixin::CTX_CLOUD_FIELD]);
-            unset($payload[CommandV1Mixin::CTX_IP_FIELD]);
-            unset($payload[CommandV1Mixin::CTX_IPV6_FIELD]);
-            unset($payload[CommandV1Mixin::CTX_UA_FIELD]);
+            unset($payload['command_id']);
+            unset($payload['occurred_at']);
+            unset($payload['expected_etag']);
+            // unset($payload['ctx_retries']);
+            unset($payload['ctx_correlator_ref']);
+            unset($payload['ctx_app']);
+            unset($payload['ctx_cloud']);
+            unset($payload['ctx_ip']);
+            unset($payload['ctx_ipv6']);
+            unset($payload['ctx_ua']);
 
             $params = [
                 'TableName'    => $tableName,

--- a/src/SimpleEventBus.php
+++ b/src/SimpleEventBus.php
@@ -78,17 +78,14 @@ final class SimpleEventBus implements EventBus
                 $code = $e->getCode() > 0 ? $e->getCode() : Code::UNKNOWN;
 
                 $failedEvent = EventExecutionFailedV1::create()
-                    ->set(EventExecutionFailedV1::EVENT_FIELD, $event)
-                    ->set(EventExecutionFailedV1::ERROR_CODE_FIELD, $code)
-                    ->set(EventExecutionFailedV1::ERROR_NAME_FIELD, ClassUtil::getShortName($e))
-                    ->set(EventExecutionFailedV1::ERROR_MESSAGE_FIELD, substr($e->getMessage(), 0, 2048))
-                    ->set(EventExecutionFailedV1::STACK_TRACE_FIELD, $e->getTraceAsString());
+                    ->set('event', $event)
+                    ->set('error_code', $code)
+                    ->set('error_name', ClassUtil::getShortName($e))
+                    ->set('error_message', substr($e->getMessage(), 0, 2048))
+                    ->set('stack_trace', $e->getTraceAsString());
 
                 if ($e->getPrevious()) {
-                    $failedEvent->set(
-                        EventExecutionFailedV1::PREV_ERROR_MESSAGE_FIELD,
-                        substr($e->getPrevious()->getMessage(), 0, 2048)
-                    );
+                    $failedEvent->set('prev_error_message', substr($e->getPrevious()->getMessage(), 0, 2048));
                 }
 
                 $this->pbjx->copyContext($event, $failedEvent);

--- a/src/SimplePbjx.php
+++ b/src/SimplePbjx.php
@@ -16,9 +16,6 @@ use Gdbots\Pbjx\Exception\InvalidArgumentException;
 use Gdbots\Pbjx\Exception\LogicException;
 use Gdbots\Pbjx\Exception\RequestHandlingFailed;
 use Gdbots\Pbjx\Exception\TooMuchRecursion;
-use Gdbots\Schemas\Pbjx\Mixin\Command\CommandV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\Event\EventV1Mixin;
-use Gdbots\Schemas\Pbjx\Mixin\Request\RequestV1Mixin;
 use Gdbots\Schemas\Pbjx\Request\RequestFailedResponseV1;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -99,16 +96,11 @@ final class SimplePbjx implements Pbjx
 
         $schema = $to::schema();
 
-        if (!$to->has(CommandV1Mixin::CTX_CAUSATOR_REF_FIELD)
-            && $schema->hasField(CommandV1Mixin::CTX_CAUSATOR_REF_FIELD)
-        ) {
-            $to->set(CommandV1Mixin::CTX_CAUSATOR_REF_FIELD, $from->generateMessageRef());
+        if (!$to->has('ctx_causator_ref') && $schema->hasField('ctx_causator_ref')) {
+            $to->set('ctx_causator_ref', $from->generateMessageRef());
         }
 
-        $clone = [
-            CommandV1Mixin::CTX_APP_FIELD,
-            CommandV1Mixin::CTX_CLOUD_FIELD,
-        ];
+        $clone = ['ctx_app', 'ctx_cloud'];
 
         foreach ($clone as $field) {
             if (!$to->has($field) && $from->has($field) && $schema->hasField($field)) {
@@ -117,13 +109,13 @@ final class SimplePbjx implements Pbjx
         }
 
         $simple = [
-            CommandV1Mixin::CTX_TENANT_ID_FIELD,
-            CommandV1Mixin::CTX_CORRELATOR_REF_FIELD,
-            CommandV1Mixin::CTX_USER_REF_FIELD,
-            CommandV1Mixin::CTX_IP_FIELD,
-            CommandV1Mixin::CTX_IPV6_FIELD,
-            CommandV1Mixin::CTX_UA_FIELD,
-            CommandV1Mixin::CTX_MSG_FIELD,
+            'ctx_tenant_id',
+            'ctx_correlator_ref',
+            'ctx_user_ref',
+            'ctx_ip',
+            'ctx_ipv6',
+            'ctx_ua',
+            'ctx_msg',
         ];
 
         foreach ($simple as $field) {
@@ -137,8 +129,8 @@ final class SimplePbjx implements Pbjx
 
     public function send(Message $command): void
     {
-        if (!$command::schema()->hasMixin(CommandV1Mixin::SCHEMA_CURIE)) {
-            throw new LogicException('Pbjx->send requires a message using "' . CommandV1Mixin::SCHEMA_CURIE . '".');
+        if (!$command::schema()->hasMixin('gdbots:pbjx:mixin:command')) {
+            throw new LogicException('Pbjx->send requires a message using "gdbots:pbjx:mixin:command".');
         }
 
         $this->triggerLifecycle($command);
@@ -151,8 +143,8 @@ final class SimplePbjx implements Pbjx
             throw new LogicException('Pbjx->sendAt requires a timestamp in the future.');
         }
 
-        if (!$command::schema()->hasMixin(CommandV1Mixin::SCHEMA_CURIE)) {
-            throw new LogicException('Pbjx->sendAt requires a message using "' . CommandV1Mixin::SCHEMA_CURIE . '".');
+        if (!$command::schema()->hasMixin('gdbots:pbjx:mixin:command')) {
+            throw new LogicException('Pbjx->sendAt requires a message using "gdbots:pbjx:mixin:command".');
         }
 
         $this->triggerLifecycle($command);
@@ -167,8 +159,8 @@ final class SimplePbjx implements Pbjx
 
     public function publish(Message $event): void
     {
-        if (!$event::schema()->hasMixin(EventV1Mixin::SCHEMA_CURIE)) {
-            throw new LogicException('Pbjx->publish requires a message using "' . EventV1Mixin::SCHEMA_CURIE . '".');
+        if (!$event::schema()->hasMixin('gdbots:pbjx:mixin:event')) {
+            throw new LogicException('Pbjx->publish requires a message using "gdbots:pbjx:mixin:event".');
         }
 
         $this->triggerLifecycle($event);
@@ -177,8 +169,8 @@ final class SimplePbjx implements Pbjx
 
     public function request(Message $request): Message
     {
-        if (!$request::schema()->hasMixin(RequestV1Mixin::SCHEMA_CURIE)) {
-            throw new LogicException('Pbjx->request requires a message using "' . RequestV1Mixin::SCHEMA_CURIE . '".');
+        if (!$request::schema()->hasMixin('gdbots:pbjx:mixin:request')) {
+            throw new LogicException('Pbjx->request requires a message using "gdbots:pbjx:mixin:request".');
         }
 
         $this->triggerLifecycle($request);

--- a/src/SimpleRequestBus.php
+++ b/src/SimpleRequestBus.php
@@ -7,7 +7,6 @@ use Gdbots\Pbj\Message;
 use Gdbots\Pbj\Util\ClassUtil;
 use Gdbots\Pbjx\Transport\Transport;
 use Gdbots\Schemas\Pbjx\Enum\Code;
-use Gdbots\Schemas\Pbjx\Mixin\Response\ResponseV1Mixin;
 use Gdbots\Schemas\Pbjx\Request\RequestFailedResponseV1;
 
 final class SimpleRequestBus implements RequestBus
@@ -41,17 +40,11 @@ final class SimpleRequestBus implements RequestBus
             $response->set('ctx_request_ref', $request->generateMessageRef());
 
             if ($request->has('ctx_correlator_ref')) {
-                $response->set(
-                    'ctx_correlator_ref',
-                    $request->get('ctx_correlator_ref')
-                );
+                $response->set('ctx_correlator_ref', $request->get('ctx_correlator_ref'));
             }
 
             if ($request->has('ctx_tenant_id')) {
-                $response->set(
-                    'ctx_tenant_id',
-                    $request->get('ctx_tenant_id')
-                );
+                $response->set('ctx_tenant_id', $request->get('ctx_tenant_id'));
             }
 
             return $response;
@@ -73,24 +66,15 @@ final class SimpleRequestBus implements RequestBus
             ->set('stack_trace', $exception->getTraceAsString());
 
         if ($exception->getPrevious()) {
-            $response->set(
-                'prev_error_message',
-                substr($exception->getPrevious()->getMessage(), 0, 2048)
-            );
+            $response->set('prev_error_message', substr($exception->getPrevious()->getMessage(), 0, 2048));
         }
 
         if ($request->has('ctx_correlator_ref')) {
-            $response->set(
-                'ctx_correlator_ref',
-                $request->get('ctx_correlator_ref')
-            );
+            $response->set('ctx_correlator_ref', $request->get('ctx_correlator_ref'));
         }
 
         if ($request->has('ctx_tenant_id')) {
-            $response->set(
-                'ctx_tenant_id',
-                $request->get('ctx_tenant_id')
-            );
+            $response->set('ctx_tenant_id', $request->get('ctx_tenant_id'));
         }
 
         return $response;

--- a/src/SimpleRequestBus.php
+++ b/src/SimpleRequestBus.php
@@ -38,19 +38,19 @@ final class SimpleRequestBus implements RequestBus
             $request->freeze();
             $handler = $this->locator->getRequestHandler($request::schema()->getCurie());
             $response = $handler->handleRequest($request, $this->locator->getPbjx());
-            $response->set(ResponseV1Mixin::CTX_REQUEST_REF_FIELD, $request->generateMessageRef());
+            $response->set('ctx_request_ref', $request->generateMessageRef());
 
-            if ($request->has(ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD)) {
+            if ($request->has('ctx_correlator_ref')) {
                 $response->set(
-                    ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD,
-                    $request->get(ResponseV1Mixin::CTX_CORRELATOR_REF_FIELD)
+                    'ctx_correlator_ref',
+                    $request->get('ctx_correlator_ref')
                 );
             }
 
-            if ($request->has(ResponseV1Mixin::CTX_TENANT_ID_FIELD)) {
+            if ($request->has('ctx_tenant_id')) {
                 $response->set(
-                    ResponseV1Mixin::CTX_TENANT_ID_FIELD,
-                    $request->get(ResponseV1Mixin::CTX_TENANT_ID_FIELD)
+                    'ctx_tenant_id',
+                    $request->get('ctx_tenant_id')
                 );
             }
 
@@ -65,31 +65,31 @@ final class SimpleRequestBus implements RequestBus
         $code = $exception->getCode() > 0 ? $exception->getCode() : Code::UNKNOWN;
 
         $response = RequestFailedResponseV1::create()
-            ->set(RequestFailedResponseV1::CTX_REQUEST_REF_FIELD, $request->generateMessageRef())
-            ->set(RequestFailedResponseV1::CTX_REQUEST_FIELD, $request)
-            ->set(RequestFailedResponseV1::ERROR_CODE_FIELD, $code)
-            ->set(RequestFailedResponseV1::ERROR_NAME_FIELD, ClassUtil::getShortName($exception))
-            ->set(RequestFailedResponseV1::ERROR_MESSAGE_FIELD, substr($exception->getMessage(), 0, 2048))
-            ->set(RequestFailedResponseV1::STACK_TRACE_FIELD, $exception->getTraceAsString());
+            ->set('ctx_request_ref', $request->generateMessageRef())
+            ->set('ctx_request', $request)
+            ->set('error_code', $code)
+            ->set('error_name', ClassUtil::getShortName($exception))
+            ->set('error_message', substr($exception->getMessage(), 0, 2048))
+            ->set('stack_trace', $exception->getTraceAsString());
 
         if ($exception->getPrevious()) {
             $response->set(
-                RequestFailedResponseV1::PREV_ERROR_MESSAGE_FIELD,
+                'prev_error_message',
                 substr($exception->getPrevious()->getMessage(), 0, 2048)
             );
         }
 
-        if ($request->has(RequestFailedResponseV1::CTX_CORRELATOR_REF_FIELD)) {
+        if ($request->has('ctx_correlator_ref')) {
             $response->set(
-                RequestFailedResponseV1::CTX_CORRELATOR_REF_FIELD,
-                $request->get(RequestFailedResponseV1::CTX_CORRELATOR_REF_FIELD)
+                'ctx_correlator_ref',
+                $request->get('ctx_correlator_ref')
             );
         }
 
-        if ($request->has(RequestFailedResponseV1::CTX_TENANT_ID_FIELD)) {
+        if ($request->has('ctx_tenant_id')) {
             $response->set(
-                RequestFailedResponseV1::CTX_TENANT_ID_FIELD,
-                $request->get(RequestFailedResponseV1::CTX_TENANT_ID_FIELD)
+                'ctx_tenant_id',
+                $request->get('ctx_tenant_id')
             );
         }
 

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -135,32 +135,23 @@ abstract class AbstractTransport implements Transport
         $code = $exception->getCode() > 0 ? $exception->getCode() : Code::UNKNOWN;
 
         $response = RequestFailedResponseV1::create()
-            ->set(RequestFailedResponseV1::CTX_REQUEST_REF_FIELD, $request->generateMessageRef())
-            ->set(RequestFailedResponseV1::CTX_REQUEST_FIELD, $request)
-            ->set(RequestFailedResponseV1::ERROR_CODE_FIELD, $code)
-            ->set(RequestFailedResponseV1::ERROR_NAME_FIELD, ClassUtil::getShortName($exception))
-            ->set(RequestFailedResponseV1::ERROR_MESSAGE_FIELD, substr($exception->getMessage(), 0, 2048))
-            ->set(RequestFailedResponseV1::STACK_TRACE_FIELD, $exception->getTraceAsString());
+            ->set('ctx_request_ref', $request->generateMessageRef())
+            ->set('ctx_request', $request)
+            ->set('error_code', $code)
+            ->set('error_name', ClassUtil::getShortName($exception))
+            ->set('error_message', substr($exception->getMessage(), 0, 2048))
+            ->set('stack_trace', $exception->getTraceAsString());
 
         if ($exception->getPrevious()) {
-            $response->set(
-                RequestFailedResponseV1::PREV_ERROR_MESSAGE_FIELD,
-                substr($exception->getPrevious()->getMessage(), 0, 2048)
-            );
+            $response->set('prev_error_message', substr($exception->getPrevious()->getMessage(), 0, 2048));
         }
 
-        if ($request->has(RequestFailedResponseV1::CTX_CORRELATOR_REF_FIELD)) {
-            $response->set(
-                RequestFailedResponseV1::CTX_CORRELATOR_REF_FIELD,
-                $request->get(RequestFailedResponseV1::CTX_CORRELATOR_REF_FIELD)
-            );
+        if ($request->has('ctx_correlator_ref')) {
+            $response->set('ctx_correlator_ref', $request->get('ctx_correlator_ref'));
         }
 
-        if ($request->has(RequestFailedResponseV1::CTX_TENANT_ID_FIELD)) {
-            $response->set(
-                RequestFailedResponseV1::CTX_TENANT_ID_FIELD,
-                $request->get(RequestFailedResponseV1::CTX_TENANT_ID_FIELD)
-            );
+        if ($request->has('ctx_tenant_id')) {
+            $response->set('ctx_tenant_id', $request->get('ctx_tenant_id'));
         }
 
         return $response;

--- a/tests/EventStore/InMemoryEventStoreTest.php
+++ b/tests/EventStore/InMemoryEventStoreTest.php
@@ -35,13 +35,13 @@ class InMemoryEventStoreTest extends TestCase
 
         $store->putEvents($streamId, [
             HealthCheckedV1::fromArray([
-                HealthCheckedV1::OCCURRED_AT_FIELD => '1489129155504330',
-                HealthCheckedV1::MSG_FIELD         => 'past event',
+                'occurred_at' => '1489129155504330',
+                'msg'         => 'past event',
             ]),
 
             HealthCheckedV1::fromArray([
-                HealthCheckedV1::OCCURRED_AT_FIELD => '2489129155504330',
-                HealthCheckedV1::MSG_FIELD         => 'future event',
+                'occurred_at' => '2489129155504330',
+                'msg'         => 'future event',
             ]),
         ]);
 
@@ -65,21 +65,21 @@ class InMemoryEventStoreTest extends TestCase
 
         $expectedEvents = [
             HealthCheckedV1::fromArray([
-                HealthCheckedV1::OCCURRED_AT_FIELD => '1489129155504330',
-                HealthCheckedV1::MSG_FIELD         => 'past event',
+                'occurred_at' => '1489129155504330',
+                'msg'         => 'past event',
             ]),
 
             HealthCheckedV1::fromArray([
-                HealthCheckedV1::OCCURRED_AT_FIELD => '2489129155504330',
-                HealthCheckedV1::MSG_FIELD         => 'future event',
+                'occurred_at' => '2489129155504330',
+                'msg'         => 'future event',
             ]),
         ];
         $store->putEvents($streamId, $expectedEvents);
 
-        $actualEvent = $store->getEvent($expectedEvents[0]->get(HealthCheckedV1::EVENT_ID_FIELD));
+        $actualEvent = $store->getEvent($expectedEvents[0]->get('event_id'));
         $this->assertTrue($expectedEvents[0]->equals($actualEvent));
 
-        $actualEvent = $store->getEvent($expectedEvents[1]->get(HealthCheckedV1::EVENT_ID_FIELD));
+        $actualEvent = $store->getEvent($expectedEvents[1]->get('event_id'));
         $this->assertTrue($expectedEvents[1]->equals($actualEvent));
     }
 
@@ -90,20 +90,20 @@ class InMemoryEventStoreTest extends TestCase
 
         $expectedEvents = [
             HealthCheckedV1::fromArray([
-                HealthCheckedV1::OCCURRED_AT_FIELD => '1489129155504330',
-                HealthCheckedV1::MSG_FIELD         => 'past event',
+                'occurred_at' => '1489129155504330',
+                'msg'         => 'past event',
             ]),
 
             HealthCheckedV1::fromArray([
-                HealthCheckedV1::OCCURRED_AT_FIELD => '2489129155504330',
-                HealthCheckedV1::MSG_FIELD         => 'future event',
+                'occurred_at' => '2489129155504330',
+                'msg'         => 'future event',
             ]),
         ];
         $store->putEvents($streamId, $expectedEvents);
 
         $eventIds = [
-            $expectedEvents[0]->get(HealthCheckedV1::EVENT_ID_FIELD),
-            $expectedEvents[1]->get(HealthCheckedV1::EVENT_ID_FIELD),
+            $expectedEvents[0]->get('event_id'),
+            $expectedEvents[1]->get('event_id'),
         ];
 
         $actualEvents = array_values($store->getEvents($eventIds));
@@ -118,13 +118,13 @@ class InMemoryEventStoreTest extends TestCase
         $store = $this->pbjx->getEventStore();
 
         $expectedEvent = HealthCheckedV1::fromArray([
-            HealthCheckedV1::OCCURRED_AT_FIELD => '1489129155504330',
-            HealthCheckedV1::MSG_FIELD         => 'past event',
+            'occurred_at' => '1489129155504330',
+            'msg'         => 'past event',
         ]);
         $store->putEvents($streamId, [$expectedEvent]);
 
-        $store->deleteEvent($expectedEvent->get(HealthCheckedV1::EVENT_ID_FIELD));
-        $store->getEvent($expectedEvent->get(HealthCheckedV1::EVENT_ID_FIELD));
+        $store->deleteEvent($expectedEvent->get('event_id'));
+        $store->getEvent($expectedEvent->get('event_id'));
     }
 
     public function testPutEvents(): void
@@ -134,7 +134,7 @@ class InMemoryEventStoreTest extends TestCase
         $events = [];
 
         for ($i = 0; $i < 10; $i++) {
-            $events[] = HealthCheckedV1::create()->set(HealthCheckedV1::MSG_FIELD, 'iter' . $i);
+            $events[] = HealthCheckedV1::create()->set('msg', 'iter' . $i);
         }
 
         // make sure stream contains all events after put
@@ -163,12 +163,12 @@ class InMemoryEventStoreTest extends TestCase
         $events = [];
 
         for ($i = 0; $i < 100; $i++) {
-            $events['iter' . $i] = HealthCheckedV1::create()->set(HealthCheckedV1::MSG_FIELD, 'iter' . $i);
+            $events['iter' . $i] = HealthCheckedV1::create()->set('msg', 'iter' . $i);
         }
 
         $this->store->putEvents($streamId, $events);
         foreach ($this->store->pipeEvents($streamId) as $event) {
-            unset($events[$event->get(HealthCheckedV1::MSG_FIELD)]);
+            unset($events[$event->get('msg')]);
         };
         $this->assertEmpty($events);
     }
@@ -183,7 +183,7 @@ class InMemoryEventStoreTest extends TestCase
             $events = [];
 
             for ($j = 0; $j < 100; $j++) {
-                $events[] = HealthCheckedV1::create()->set(HealthCheckedV1::MSG_FIELD, 'iter' . $j);
+                $events[] = HealthCheckedV1::create()->set('msg', 'iter' . $j);
                 $expected++;
             }
 
@@ -204,7 +204,7 @@ class InMemoryEventStoreTest extends TestCase
                 $lastIter = 0;
             }
 
-            $this->assertSame('iter' . $lastIter, $event->get(HealthCheckedV1::MSG_FIELD));
+            $this->assertSame('iter' . $lastIter, $event->get('msg'));
             $actual++;
             $lastIter++;
         }

--- a/tests/Fixtures/EchoRequestHandler.php
+++ b/tests/Fixtures/EchoRequestHandler.php
@@ -18,13 +18,10 @@ class EchoRequestHandler implements RequestHandler
 
     public function handleRequest(Message $request, Pbjx $pbjx): Message
     {
-        if ('fail' === $request->get(EchoRequestV1::MSG_FIELD)) {
+        if ('fail' === $request->get('msg')) {
             throw new \Exception('test fail');
         }
 
-        return EchoResponseV1::create()->set(
-            EchoResponseV1::MSG_FIELD,
-            $request->get(EchoRequestV1::OCCURRED_AT_FIELD)->toDateTime()->format('U.u')
-        );
+        return EchoResponseV1::create()->set('msg', $request->get('occurred_at')->toDateTime()->format('U.u'));
     }
 }

--- a/tests/SimpleCommandBusTest.php
+++ b/tests/SimpleCommandBusTest.php
@@ -13,7 +13,7 @@ class SimpleCommandBusTest extends AbstractBusTestCase
 {
     public function testSend()
     {
-        $command = CheckHealthV1::create()->set(CheckHealthV1::MSG_FIELD, 'homer');
+        $command = CheckHealthV1::create()->set('msg', 'homer');
         $handler = new CheckHealthHandler();
         $this->locator->registerCommandHandler($command::schema()->getCurie(), $handler);
         $this->pbjx->send($command);

--- a/tests/SimpleEventBusTest.php
+++ b/tests/SimpleEventBusTest.php
@@ -13,7 +13,7 @@ class SimpleEventBusTest extends AbstractBusTestCase
 {
     public function testPublish(): void
     {
-        $event = HealthCheckedV1::create()->set(HealthCheckedV1::MSG_FIELD, 'homer');
+        $event = HealthCheckedV1::create()->set('msg', 'homer');
         $that = $this;
         $dispatcher = $this->locator->getDispatcher();
 
@@ -37,7 +37,7 @@ class SimpleEventBusTest extends AbstractBusTestCase
 
     public function testEventExecutionFailed(): void
     {
-        $event = HealthCheckedV1::create()->set(HealthCheckedV1::MSG_FIELD, 'homer');
+        $event = HealthCheckedV1::create()->set('msg', 'homer');
         $dispatcher = $this->locator->getDispatcher();
         $schemaId = $event::schema()->getId();
         $handled = false;
@@ -69,7 +69,7 @@ class SimpleEventBusTest extends AbstractBusTestCase
 
     public function testEventBusExceptionEvent()
     {
-        $event = HealthCheckedV1::create()->set(HealthCheckedV1::MSG_FIELD, 'marge');
+        $event = HealthCheckedV1::create()->set('msg', 'marge');
         $that = $this;
         $dispatcher = $this->locator->getDispatcher();
         $schemaId = $event::schema()->getId();
@@ -92,10 +92,7 @@ class SimpleEventBusTest extends AbstractBusTestCase
             PbjxEvents::EVENT_BUS_EXCEPTION,
             function (BusExceptionEvent $exceptionEvent) use ($that, $event) {
                 $domainEvent = $exceptionEvent->getMessage();
-                $that->assertSame(
-                    $domainEvent->get(EventExecutionFailedV1::EVENT_FIELD)->get(HealthCheckedV1::MSG_FIELD),
-                    $event->get(HealthCheckedV1::MSG_FIELD)
-                );
+                $that->assertSame($domainEvent->get('event')->get('msg'), $event->get('msg'));
             }
         );
 

--- a/tests/SimpleRequestBusTest.php
+++ b/tests/SimpleRequestBusTest.php
@@ -23,19 +23,16 @@ class SimpleRequestBusTest extends AbstractBusTestCase
     {
         $request = EchoRequestV1::create();
         /** @var \DateTimeInterface $expected */
-        $expected = $request->get(EchoRequestV1::OCCURRED_AT_FIELD)->toDateTime();
+        $expected = $request->get('occurred_at')->toDateTime();
         $response = $this->pbjx->request($request);
         $this->assertInstanceOf(EchoResponseV1::class, $response);
-        $this->assertSame(
-            $expected->format('U.u'),
-            $response->get(EchoResponseV1::MSG_FIELD)
-        );
+        $this->assertSame($expected->format('U.u'), $response->get('msg'));
     }
 
     public function testRequestHandlingFailed()
     {
         $request = EchoRequestV1::create();
-        $request->set(EchoRequestV1::MSG_FIELD, 'fail');
+        $request->set('msg', 'fail');
 
         try {
             $this->pbjx->request($request);


### PR DESCRIPTION
* Remove use of mixin/message constants for fields and schema refs as it's too noisy and isn't enough of a help to warrant it.