### PR TITLE
v3.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ autoload.php
 composer.lock
 composer.phar
 phpunit.xml
+.phpunit.result.cache
 .buildpath
 *.iml
 .idea/

--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 3.x versions.
 
 
+## v3.1.3
+* In `IndexManager::updateIndex` add `ignore_unavailable` and `allow_no_indices` (with true) when running `$index->setMapping(...)` since a missing index is not an error in this scenario.
+
+
 ## v3.1.2
 * More mixin reference removal.
 

--- a/src/EventSearch/Elastica/IndexManager.php
+++ b/src/EventSearch/Elastica/IndexManager.php
@@ -214,7 +214,10 @@ class IndexManager
         $index = new Index($client, $name);
 
         try {
-            $index->setMapping($this->createMapping());
+            $index->setMapping($this->createMapping(), [
+                'ignore_unavailable' => true,
+                'allow_no_indices'   => true,
+            ]);
         } catch (\Throwable $e) {
             if (false !== strpos($e->getMessage(), 'no such index')) {
                 $this->logger->info(sprintf('No index exists yet [%s] in ElasticSearch. Ignoring.', $name));


### PR DESCRIPTION
* In `IndexManager::updateIndex` add `ignore_unavailable` and `allow_no_indices` (with true) when running `$index->setMapping(...)` since a missing index is not an error in this scenario.